### PR TITLE
Change `%d` to `%03d`

### DIFF
--- a/cmd/combinations/project_accounts_keys.go
+++ b/cmd/combinations/project_accounts_keys.go
@@ -114,7 +114,7 @@ func CmdCreateProjectAccountsKeys(c *cli.Context) {
 		go func(i int) {
 			defer serviceAccountRequests.Done()
 
-			accountId := fmt.Sprintf("service-account-%d", i)
+			accountId := fmt.Sprintf("service-account-%03d", i)
 
 		createServiceAccount:
 			logrus.Infof("Creating Service Account: %s", accountId)


### PR DESCRIPTION
Change `%d` to `%03d` to make leading zeros in account names for better sorting