### PR TITLE
Fix: gdrive just doesn't want to delete those files for some reason

### DIFF
--- a/cmd/delete/teamdrive.go
+++ b/cmd/delete/teamdrive.go
@@ -49,8 +49,7 @@ func CmdDeleteTeamDrive(c *cli.Context) {
 	}
 
 	if forceDelete {
-		query := fmt.Sprintf(`parents = "%s"`, teamdriveId)
-		driveFiles, err := api.ListAllObjects(driveApi, teamdriveId, query)
+		driveFiles, err := api.ListAllObjects(driveApi, teamdriveId, "")
 		if err != nil {
 			logrus.Panic(err)
 		}


### PR DESCRIPTION
Go back to recursive deleting of files in teamdrive because Google Drive just doesn't want to delete everything by removing parent objects only and it hangs TDM waiting for all objects to be deleted.